### PR TITLE
Use stringr::str_to_title() for Ensembl filenames

### DIFF
--- a/R/getENSEMBL.Annotation.R
+++ b/R/getENSEMBL.Annotation.R
@@ -102,7 +102,7 @@ getENSEMBL.Annotation <-
                 stringr::str_to_lower(new.organism),
                 "/",
                 paste0(
-                    new.organism,
+                    stringr::str_to_title(new.organism, locale = "en"),
                     ".",
                     json.qry.info$default_coord_system_version,
                     ".",
@@ -114,7 +114,7 @@ getENSEMBL.Annotation <-
         if (file.exists(file.path(
             path,
             paste0(
-                new.organism,
+                stringr::str_to_title(new.organism, locale = "en"),
                 ".",
                 json.qry.info$default_coord_system_version,
                 ".",
@@ -128,7 +128,7 @@ getENSEMBL.Annotation <-
                 file.path(
                     path,
                     paste0(
-                        new.organism,
+                        stringr::str_to_title(new.organism, locale = "en"),
                         ".",
                         json.qry.info$default_coord_system_version,
                         ".",
@@ -145,9 +145,9 @@ getENSEMBL.Annotation <-
                                 destfile = file.path(
                                     path,
                                     paste0(
-                                        new.organism,
+                                        stringr::str_to_title(new.organism, locale = "en"),
                                         ".",
-                                json.qry.info$default_coord_system_version,
+                                        json.qry.info$default_coord_system_version,
                                         ".",
                                         ensembl.available.organisms$release[1],
                                         "_ensembl",
@@ -169,7 +169,7 @@ getENSEMBL.Annotation <-
         return(file.path(
             path,
             paste0(
-                new.organism,
+                stringr::str_to_title(new.organism, locale = "en"),
                 ".",
                 json.qry.info$default_coord_system_version,
                 ".",

--- a/R/getENSEMBL.Seq.R
+++ b/R/getENSEMBL.Seq.R
@@ -74,7 +74,7 @@ getENSEMBL.Seq <- function(organism, type = "dna", id.type = "toplevel", path) {
                 type,
                 "/",
                 paste0(
-                    new.organism,
+                    stringr::str_to_title(new.organism, locale = "en"),
                     ".",
                     rest_api_status$default_coord_system_version,
                     ".",
@@ -95,7 +95,7 @@ getENSEMBL.Seq <- function(organism, type = "dna", id.type = "toplevel", path) {
         if (file.exists(file.path(
             path,
             paste0(
-                new.organism,
+                stringr::str_to_title(new.organism, locale = "en"),
                 ".",
                 rest_api_status$default_coord_system_version,
                 ".",
@@ -108,7 +108,7 @@ getENSEMBL.Seq <- function(organism, type = "dna", id.type = "toplevel", path) {
             message("File ",file.path(
                 path,
                 paste0(
-                    new.organism,
+                    stringr::str_to_title(new.organism, locale = "en"),
                     ".",
                     rest_api_status$default_coord_system_version,
                     ".",
@@ -121,7 +121,7 @@ getENSEMBL.Seq <- function(organism, type = "dna", id.type = "toplevel", path) {
             return(file.path(
                 path,
                 paste0(
-                    new.organism,
+                    stringr::str_to_title(new.organism, locale = "en"),
                     ".",
                     rest_api_status$default_coord_system_version,
                     ".",
@@ -151,7 +151,7 @@ getENSEMBL.Seq <- function(organism, type = "dna", id.type = "toplevel", path) {
                 return(file.path(
                     path,
                     paste0(
-                        new.organism,
+                        stringr::str_to_title(new.organism, locale = "en"),
                         ".",
                         rest_api_status$default_coord_system_version,
                         ".",

--- a/R/getENSEMBL.gtf.R
+++ b/R/getENSEMBL.gtf.R
@@ -116,7 +116,8 @@ getENSEMBL.gtf <-
                                 stringr::str_to_lower(new.organism),
                                 "/",
                                 paste0(
-                                        new.organism,
+                                        stringr::str_to_title(string = new.organism, 
+                                                              local = "en"),
                                         ".",
                                         json.qry.info$default_coord_system_version,
                                         ".",
@@ -128,7 +129,8 @@ getENSEMBL.gtf <-
                 if (file.exists(file.path(
                         path,
                         paste0(
-                                new.organism,
+                                stringr::str_to_title(string = new.organism, 
+                                                      locale = "en"),
                                 ".",
                                 json.qry.info$default_coord_system_version,
                                 ".",
@@ -142,7 +144,8 @@ getENSEMBL.gtf <-
                                 file.path(
                                         path,
                                         paste0(
-                                                new.organism,
+                                                stringr::str_to_title(string = new.organism, 
+                                                                      locale = "en"),
                                                 ".",
                                                 json.qry.info$default_coord_system_version,
                                                 ".",
@@ -159,7 +162,8 @@ getENSEMBL.gtf <-
                                                 destfile = file.path(
                                                         path,
                                                         paste0(
-                                                                new.organism,
+                                                                stringr::str_to_title(string = new.organism, 
+                                                                                      local = "en"),
                                                                 ".",
                                                                 json.qry.info$default_coord_system_version,
                                                                 ".",
@@ -183,7 +187,8 @@ getENSEMBL.gtf <-
                 return(file.path(
                         path,
                         paste0(
-                                new.organism,
+                                stringr::str_to_title(string = new.organism, 
+                                                      local = "en"),
                                 ".",
                                 json.qry.info$default_coord_system_version,
                                 ".",


### PR DESCRIPTION
Ensembl capitalizes the genus in the filenames on their FTP site, requiring str_to_title() to fix the name.