### PR TITLE
https and new curl fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+biomartr.Rproj

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ License: GPL-2
 LazyData: true
 URL: https://docs.ropensci.org/biomartr/, https://github.com/ropensci/biomartr
 BugReports: https://github.com/ropensci/biomartr/issues
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Encoding: UTF-8
 X-schema.org-keywords: BioMart, genomic-data-retrieval, annotation-retrieval, database-retrieval, NCBI, ENSEMBL, biological-data-retrieval 
 X-schema.org-applicationCategory: Data Access 

--- a/R/exists.ftp.file.R
+++ b/R/exists.ftp.file.R
@@ -39,8 +39,8 @@ exists.ftp.file <- function(url, file.path) {
 #' @import curl
 exists.ftp.file.new <- function(url, file.path) {
 
-
-    if (!RCurl::url.exists(dirname(url)))
+    url_dir_safe <- gsub("//$", "/", file.path(dirname(url), "/"))
+    if (!RCurl::url.exists(url_dir_safe))
         return(FALSE)
 
     con <- RCurl::getURL(url, ftp.use.epsv = FALSE, dirlistonly = TRUE)

--- a/R/get.ensembl.info.R
+++ b/R/get.ensembl.info.R
@@ -1,6 +1,6 @@
 #' @title Helper function to retrieve species information from the ENSEMBL API
 #' @description This function interfaces with the ENSEMBL API
-#' (http://rest.ensembl.org/info/species?content-type=application/json)
+#' (https://rest.ensembl.org/info/species?content-type=application/json)
 #' and internally stores the output to use this information for subsequent
 #' retrieval function calls.
 #' @author Hajk-Georg Drost
@@ -25,34 +25,34 @@ get.ensembl.info <- function(update = FALSE) {
                     )
                 )
         )
-        
+
     } else {
-            
-        
-        rest_url <- "http://rest.ensembl.org/info/species?content-type=application/json"
+
+
+        rest_url <- "https://rest.ensembl.org/info/species?content-type=application/json"
         rest_api_status <- curl::curl_fetch_memory(rest_url)
         if (rest_api_status$status_code != 200) {
             message(
-                "The API 'http://rest.ensembl.org' does not seem to
+                "The API 'https://rest.ensembl.org' does not seem to
                 respond or work properly. Is the homepage 'http://rest.ensembl.org' currently available?",
                 " Could it be that there is a firewall issue on your side? Please re-run the function and check if it works now."
             )
         }
-    
+
             ensembl.info <-
                 tibble::as_tibble(
                     jsonlite::fromJSON(
                         rest_url
                     )$species
                 )
-        
+
         aliases <- groups <- NULL
         ensembl.info <-
             dplyr::select(ensembl.info, -aliases, -groups)
-        
+
         readr::write_tsv(ensembl.info,
                          file.path(tempdir(), "ensembl_info.tsv"))
     }
-    
+
     return(ensembl.info)
 }

--- a/R/get.ensemblgenome.info.R
+++ b/R/get.ensemblgenome.info.R
@@ -1,6 +1,6 @@
-#' @title Helper function to retrieve species information 
+#' @title Helper function to retrieve species information
 #' from the ENSEMBLGENOMES API
-#' @description This function interfaces with the ENSEMBL API 
+#' @description This function interfaces with the ENSEMBL API
 #' (http://rest.ensemblgenomes.org/info/species?content-type=application/json)
 #' and internally stores the output to use this information for subsequent
 #' retrieval function calls.
@@ -26,38 +26,38 @@ get.ensemblgenome.info <- function(update = FALSE) {
                     )
                 )
         )
-    
+
     } else {
-        
+
         message("Starting retrieval of information for all species stored in ENSEMBLGENOMES... This needs to be done only once.")
-        
-        rest_url <- "http://rest.ensembl.org/info/species?content-type=application/json"
+
+        rest_url <- "https://rest.ensembl.org/info/species?content-type=application/json"
         rest_api_status <- curl::curl_fetch_memory(rest_url)
-        
+
         if (rest_api_status$status_code != 200) {
             message(
-                "The API 'rest.ensembl.org' does not 
+                "The API 'rest.ensembl.org' does not
                 seem to respond or work properly.
-                Is the homepage 'rest.ensembl.org' 
-                currently available?", 
+                Is the homepage 'rest.ensembl.org'
+                currently available?",
                 " Could it be that there is a firewall issue on your side? Please re-run the function and check if it works now."
             )
         }
-        
+
             ensemblgenome.info <-
                 tibble::as_tibble(
                     jsonlite::fromJSON(
                         rest_url
                     )$species
                 )
-        
+
         aliases <- groups <- NULL
         ensemblgenome.info <-
             dplyr::select(ensemblgenome.info, -aliases, -groups)
-        
+
         readr::write_tsv(ensemblgenome.info,
                          file.path(tempdir(), "ensemblgenome_info.tsv"))
     }
-    
+
     return(ensemblgenome.info)
 }

--- a/R/getENSEMBL.Seq.R
+++ b/R/getENSEMBL.Seq.R
@@ -57,7 +57,7 @@ getENSEMBL.Seq <- function(organism, type = "dna", id.type = "toplevel", release
 
 
     rest_url <- paste0(
-        "http://rest.ensembl.org/info/assembly/",
+        "https://rest.ensembl.org/info/assembly/",
         new.organism,
         "?content-type=application/json"
     )
@@ -68,7 +68,7 @@ getENSEMBL.Seq <- function(organism, type = "dna", id.type = "toplevel", release
     }
 
     release_api <- jsonlite::fromJSON(
-            "http://rest.ensembl.org/info/data/?content-type=application/json"
+            "https://rest.ensembl.org/info/data/?content-type=application/json"
     )$releases
 
     if (!is.null(release)){

--- a/R/getENSEMBL.gtf.R
+++ b/R/getENSEMBL.gtf.R
@@ -50,7 +50,7 @@ getENSEMBL.gtf <- function(organism, type = "dna", id.type = "toplevel",
 
 
     rest_url <- paste0(
-        "http://rest.ensembl.org/info/assembly/",
+        "https://rest.ensembl.org/info/assembly/",
         new.organism,
         "?content-type=application/json"
     )

--- a/R/getReleases.R
+++ b/R/getReleases.R
@@ -1,59 +1,59 @@
-#' @title Retrieve available database releases or versions 
+#' @title Retrieve available database releases or versions
 #' of ENSEMBL
-#' @description Retrieve available database releases or versions of 
+#' @description Retrieve available database releases or versions of
 #' ENSEMBL.
-#' @param db a character string specifying the database from which 
+#' @param db a character string specifying the database from which
 #' available resease versions shall be retrieved:
 #' \itemize{
 #' \item \code{db = "ensembl"}
 #' }
 #' @author Hajk-Georg Drost
 #' @examples
-#' \dontrun{ 
+#' \dontrun{
 #' # retrieve available resease versions of ENSEMBL
 #' getReleases("ensembl")
 #' }
 #' @export
 getReleases <- function(db = "ensembl") {
-    
+
     if (!is.element(db, c("ensembl")))
         stop(
             "Please select one of the available databases: 'ensembl'.",
             call. = FALSE
         )
-    
+
     if (db == "ensembl") {
-      
-        tryCatch({  
+
+        tryCatch({
         current_release <-
             jsonlite::fromJSON(
-"http://rest.ensembl.org/info/data/?content-type=application/json")$releases
+"https://rest.ensembl.org/info/data/?content-type=application/json")$releases
         }, error = function(e)
             message(
-                "The API 'http://rest.ensembl.org' does not seem 
-                to be reachable. Could you please check whether you are connected to the internet? 
-                Is it possible to access the homepage 'http://rest.ensembl.org' 
+                "The API 'https://rest.ensembl.org' does not seem
+                to be reachable. Could you please check whether you are connected to the internet?
+                Is it possible to access the homepage 'http://rest.ensembl.org'
                 via your browser?"
             ))
-        
+
         message("The current ENSEMBL release is release-", current_release, ".")
         return(paste0("release-", seq_len(current_release)))
     }
 
     if (db == "ensemblgenomes") {
-        
-        tryCatch({  
+
+        tryCatch({
             current_release <-
                 jsonlite::fromJSON(
-"http://rest.ensembl.org/info/data/?content-type=application/json")$releases
+"https://rest.ensembl.org/info/data/?content-type=application/json")$releases
         }, error = function(e)
           message(
-            "The API 'http://rest.ensembl.org' does not seem 
-                to be reachable. Could you please check whether you are connected to the internet? 
-                Is it possible to access the homepage 'http://rest.ensembl.org' 
+            "The API 'http://rest.ensembl.org' does not seem
+                to be reachable. Could you please check whether you are connected to the internet?
+                Is it possible to access the homepage 'https://rest.ensembl.org'
                 via your browser?"
           ))
-        
+
         message("The current ENSEMBL release is release-",
                 current_release, ".")
         return(paste0("release-", seq_len(current_release)))

--- a/man/getReleases.Rd
+++ b/man/getReleases.Rd
@@ -2,24 +2,24 @@
 % Please edit documentation in R/getReleases.R
 \name{getReleases}
 \alias{getReleases}
-\title{Retrieve available database releases or versions 
+\title{Retrieve available database releases or versions
 of ENSEMBL}
 \usage{
 getReleases(db = "ensembl")
 }
 \arguments{
-\item{db}{a character string specifying the database from which 
+\item{db}{a character string specifying the database from which
 available resease versions shall be retrieved:
 \itemize{
 \item \code{db = "ensembl"}
 }}
 }
 \description{
-Retrieve available database releases or versions of 
+Retrieve available database releases or versions of
 ENSEMBL.
 }
 \examples{
-\dontrun{ 
+\dontrun{
 # retrieve available resease versions of ENSEMBL
 getReleases("ensembl")
 }


### PR DESCRIPTION
Hello again, times are changing and https URLs is now starting to be enforced for many systems.

That being the case I fear biomartr will start to fail for many of the calls to older "http" URLs.
I here did a small fix for the most important links for ensemble genomes. 
To keep biomartr alive, hopefully if enough people do some small fixes when needed it can continue to function properly.

Secondly, the newest curl-lib now enforces a trailing slash on URL directories, which made one of your FTP file checkers fail.
I made a safety wrapper for the dir check, that always enforces a single slash end.

The changes I made are completely backwards compatible for others, while making it not crash on people with newer systems.

I tested it on 2 systems, and ran your checks.

I see that your full checks (The ones ignored on CRAN) fails for several points, by giving https links I fixed some of them, but a new commit is needed to fix more of them.
Idealy some of your links should be moved out to a single function, so that if it ever changes in the future, there will be only 1 line to edit instead of a 100 which it is currently. 

Especially this call:
```
jsonlite::fromJSON(
            "http://rest.ensembl.org/info/data/?content-type=application/json"
    )$releases
```
Which I changed to:
```
jsonlite::fromJSON(
            "https://rest.ensembl.org/info/data/?content-type=application/json"
    )$releases
```

It is used over 20 times, and it is far from the only one. So there is a lot of redundancy that could be moved to a single function :)

Merry Christmas :)
