### PR TITLE
Fixing proteom for ensembl genomes species, issue 84

### DIFF
--- a/R/Refseq_Genbank_Annotation.R
+++ b/R/Refseq_Genbank_Annotation.R
@@ -119,7 +119,8 @@ refseq_genbank_download_post_processing <- function(info, organism, db, path,
                                                     gunzip,
                                                     remove_annotation_outliers,
                                                     format,
-                                                    analyse_genome = FALSE) {
+                                                    analyse_genome = FALSE,
+                                                    mute_citation = FALSE) {
   if ((is.logical(info[1]) && !info) || (info[1] == "Not available"))
     return("Not available")
 
@@ -158,5 +159,6 @@ refseq_genbank_download_post_processing <- function(info, organism, db, path,
   doc_file_path <- file.path(path,
                              paste0("doc_", local.org, "_db_", db, ".tsv"))
   readr::write_tsv(doc, file = doc_file_path)
-  gunzip_and_check(local_file, gunzip, remove_annotation_outliers, format)
+  gunzip_and_check(local_file, gunzip, remove_annotation_outliers, format,
+                   mute_citation = mute_citation)
 }

--- a/R/getENSEMBLInfo.R
+++ b/R/getENSEMBLInfo.R
@@ -378,7 +378,8 @@ write_assembly_docs_ensembl <- function(genome.path, new.organism, db, json.qry.
 
 ensembl_download_post_processing <- function(genome.path, organism, format,
                                              remove_annotation_outliers = FALSE,
-                                             gunzip = FALSE, db = "ensembl") {
+                                             gunzip = FALSE, db = "ensembl",
+                                             mute_citation = FALSE) {
   if (is.logical(genome.path[1]) && !genome.path) {
     return(FALSE)
   } else {
@@ -390,7 +391,8 @@ ensembl_download_post_processing <- function(genome.path, organism, format,
     write_assembly_docs_ensembl(genome.path, new.organism = info$new.organism,
                                 db = db, json.qry.info = info$json.qry.info, append = append)
     local_file <- genome.path[1]
-    return(gunzip_and_check(local_file, gunzip, remove_annotation_outliers, format))
+
+    gunzip_and_check(local_file, gunzip, remove_annotation_outliers, format, mute_citation)
   }
 }
 

--- a/R/getGFF.R
+++ b/R/getGFF.R
@@ -99,7 +99,8 @@ getGFF <- function(db = "refseq", organism, reference = FALSE,
       return(refseq_genbank_download_post_processing(info, organism, db, path,
                                                      gunzip,
                                                      remove_annotation_outliers,
-                                                     format))
+                                                     format,
+                                                     mute_citation = mute_citation))
     }
 
     if (db == "ensembl") {
@@ -108,7 +109,8 @@ getGFF <- function(db = "refseq", organism, reference = FALSE,
                                              format = format)
         return(ensembl_download_post_processing(genome.path, organism, format,
                                                 remove_annotation_outliers,
-                                                gunzip))
+                                                gunzip,
+                                                mute_citation = mute_citation))
     }
 }
 

--- a/R/getGenome.R
+++ b/R/getGenome.R
@@ -118,7 +118,8 @@ getGenome <- function(db = "refseq",
                                                      gunzip,
                                                      remove_annotation_outliers,
                                                      format = "genome",
-                                                     analyse_genome = analyse_genome))
+                                                     analyse_genome = analyse_genome,
+                                                     mute_citation = mute_citation))
     }
 
     if (db %in% c("ensembl", "ensemblgenomes")) {
@@ -128,7 +129,8 @@ getGenome <- function(db = "refseq",
                                       path = path)
         ensembl_download_post_processing(genome.path, organism,
                                          format = "genome",
-                                         gunzip = gunzip)
+                                         gunzip = gunzip,
+                                         mute_citation = mute_citation)
     }
 }
 

--- a/R/getMetaGenomeSummary.R
+++ b/R/getMetaGenomeSummary.R
@@ -1,5 +1,5 @@
 #' @title Retrieve the assembly_summary.txt file from NCBI genbank metagenomes
-#' @description Retrieval function of the assembly_summary.txt file 
+#' @description Retrieval function of the assembly_summary.txt file
 #' from NCBI genbank metagenomes.
 #' This files stores all available metagenome projects on NCBI Genbank.
 #' @author Hajk-Georg Drost
@@ -8,38 +8,17 @@
 #' meta.summary <- getMetaGenomeSummary()
 #' meta.summary
 #' }
-#' @seealso \code{\link{getKingdomAssemblySummary}}, 
+#' @seealso \code{\link{getKingdomAssemblySummary}},
 #' \code{\link{getSummaryFile}}
 #' @export
- 
-getMetaGenomeSummary <- function() {
-    
-    if (!file.exists(file.path(tempdir(),
-                               "assembly_summary_metagenomes_genbank.txt"))) {
-        tryCatch({
-            suppressMessages(
-                downloader::download(
-  "ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/metagenomes/assembly_summary.txt",
-                    destfile = file.path(
-                        tempdir(),
-                        "assembly_summary_metagenomes_genbank.txt"
-                    )
-                )
-            )
-        }, error = function(e)
-            message(
-                "Unfortunately, the FTP site 'ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/metagenomes/assembly_summary.txt'",
-                " cannot be reached. This might be due to an instable internet connection or some issues with the firewall. ", 
-                "Are you able to access the FTP site 'ftp://ftp.ncbi.nlm.nih.gov/' in your browser?",
-                " Please try to re-run this function and see if it may work then ..."
-            ))
-    }
-    
+
+getMetaGenomeSummary <- function(local_file = file.path(cachedir(), "assembly_summary_metagenomes_genbank.txt")) {
+    url <- "ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/metagenomes/assembly_summary.txt"
+    custom_download_check_local(url, local_file, NULL, db = "genbank")
     suppressWarnings(summary.file <-
                          tibble::as_tibble(
                              readr::read_delim(
-                                 file.path(tempdir(),
-                                    "assembly_summary_metagenomes_genbank.txt"),
+                                 local_file,
                                  comment = "#",
                                  delim = "\t",
                                  quote = "\"",
@@ -92,6 +71,6 @@ getMetaGenomeSummary <- function() {
                                  )
                              )
                          ))
-    
+
     return(summary.file)
 }

--- a/R/getProteome.R
+++ b/R/getProteome.R
@@ -1,10 +1,10 @@
 #' @title Proteome Retrieval
 #' @description Main proteome retrieval function for an organism of interest.
-#' By specifying the scientific name of an organism of interest the 
+#' By specifying the scientific name of an organism of interest the
 #' corresponding fasta-file storing the proteome of the organism of interest
-#' can be downloaded and stored locally. Proteome files can be retrieved from 
+#' can be downloaded and stored locally. Proteome files can be retrieved from
 #' several databases.
-#' @param db a character string specifying the database from which the genome 
+#' @param db a character string specifying the database from which the genome
 #' shall be retrieved:
 #' \itemize{
 #' \item \code{db = "refseq"}
@@ -12,55 +12,55 @@
 #' \item \code{db = "ensembl"}
 #' \item \code{db = "uniprot"}
 #' }
-#' @param organism there are three options to characterize an organism: 
+#' @param organism there are three options to characterize an organism:
 #' \itemize{
 #' \item by \code{scientific name}: e.g. \code{organism = "Homo sapiens"}
 #' \item by \code{database specific accession identifier}: e.g. \code{organism = "GCF_000001405.37"} (= NCBI RefSeq identifier for \code{Homo sapiens})
 #' \item by \code{taxonomic identifier from NCBI Taxonomy}: e.g. \code{organism = "9606"} (= taxid of \code{Homo sapiens})
 #' }
 #' @param reference a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.
-#' @param skip_bacteria Due to its enormous dataset size (> 700MB as of July 2023), 
+#' @param skip_bacteria Due to its enormous dataset size (> 700MB as of July 2023),
 #' the bacterial summary file will not be loaded by default anymore. If users
-#' wish to gain insights for the bacterial kingdom they needs to actively specify \code{skip_bacteria = FALSE}. When \code{skip_bacteria = FALSE} is set then the 
-#' bacterial summary file will be downloaded.   
+#' wish to gain insights for the bacterial kingdom they needs to actively specify \code{skip_bacteria = FALSE}. When \code{skip_bacteria = FALSE} is set then the
+#' bacterial summary file will be downloaded.
 #' @param release the database release version of ENSEMBL (\code{db = "ensembl"}). Default is \code{release = NULL} meaning
 #' that the most recent database version is used.
 #' @param gunzip a logical value indicating whether or not files should be unzipped.
-#' @param path a character string specifying the location (a folder) in which 
-#' the corresponding proteome shall be stored. Default is 
+#' @param path a character string specifying the location (a folder) in which
+#' the corresponding proteome shall be stored. Default is
 #' \code{path} = \code{file.path("_ncbi_downloads","proteomes")}.
 #' @param mute_citation logical value indicating whether citation message should be muted.
 #' @author Hajk-Georg Drost
 #' @details Internally this function loads the the overview.txt file from NCBI:
-#' 
+#'
 #'  refseq: ftp://ftp.ncbi.nlm.nih.gov/genomes/refseq/
-#'  
+#'
 #'  genbank: ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/
-#' 
+#'
 #' and creates a directory '_ncbi_downloads/proteomes' to store
 #' the proteome of interest as fasta file for future processing.
 #' @return File path to downloaded proteome.
 #' @examples \dontrun{
-#' 
+#'
 #' # download the proteome of Arabidopsis thaliana from refseq
 #' # and store the corresponding proteome file in '_ncbi_downloads/proteomes'
-#' file_path <- getProteome( db       = "refseq", 
-#'              organism = "Arabidopsis thaliana", 
+#' file_path <- getProteome( db       = "refseq",
+#'              organism = "Arabidopsis thaliana",
 #'              path     = file.path("_ncbi_downloads","proteomes") )
-#' 
+#'
 #' Ath_proteome <- read_proteome(file_path, format = "fasta")
-#' 
+#'
 #' # download the proteome of Arabidopsis thaliana from genbank
 #' # and store the corresponding proteome file in '_ncbi_downloads/proteomes'
-#' file_path <- getProteome( db       = "genbank", 
-#'              organism = "Arabidopsis thaliana", 
+#' file_path <- getProteome( db       = "genbank",
+#'              organism = "Arabidopsis thaliana",
 #'              path     = file.path("_ncbi_downloads","proteomes") )
-#' 
+#'
 #' Ath_proteome <- read_proteome(file_path, format = "fasta")
 #' }
 #' @seealso \code{\link{getGenome}}, \code{\link{getCDS}}, \code{\link{getGFF}},
-#' \code{\link{getRNA}}, \code{\link{getRepeatMasker}}, 
-#' \code{\link{getAssemblyStats}}, \code{\link{getCollection}}, \code{\link{meta.retrieval}}, 
+#' \code{\link{getRNA}}, \code{\link{getRepeatMasker}},
+#' \code{\link{getAssemblyStats}}, \code{\link{getCollection}}, \code{\link{meta.retrieval}},
 #' \code{\link{read_proteome}}
 #' @export
 
@@ -73,33 +73,39 @@ getProteome <-
              gunzip = FALSE,
              path = file.path("_ncbi_downloads", "proteomes"),
              mute_citation = FALSE) {
-        if (!is.element(db, c("refseq", "genbank", 
-                              "ensembl", "uniprot", "ensemblgenomes")))
-            stop(
-                "Please select one of the available data bases: 
-                'refseq', 'genbank', 'ensembl', 'uniprot', or 'ensemblgenomes'.",
-                call. = FALSE
-            )
-        
-        if (db == "ensemblgenomes") {
-                organism_name <- is.genome.available(db = db, organism = organism, details = TRUE)$display_name[1]
-                
-                if (!is.na(organism_name))
-                        message("Starting proteome retrieval of '", organism_name, "' from ", db, " ...")
-                if (is.na(organism_name))
-                        message("Starting proteome retrieval of '", organism, "' from ", db, " ...")
-                
-                message("\n")
-        } else {
-            message("-> Starting proteome retrieval of '", organism, "' from ", db, " ...")
-            message("\n")
-        }
-        
+      if (!is.element(db, c("refseq", "genbank",
+                            "ensembl", "uniprot", "ensemblgenomes")))
+          stop(
+              "Please select one of the available data bases:
+              'refseq', 'genbank', 'ensembl', 'uniprot', or 'ensemblgenomes'.",
+              call. = FALSE
+          )
+
+      # create result folder
+      if (!file.exists(path)) {
+        dir.create(path, recursive = TRUE)
+      }
+
+      if (db == "ensemblgenomes") {
+              organism_name <- is.genome.available(db = db, organism = organism, details = TRUE)$display_name[1]
+
+              if (!is.na(organism_name))
+                      message("Starting proteome retrieval of '", organism_name, "' from ", db, " ...")
+              if (is.na(organism_name))
+                      message("Starting proteome retrieval of '", organism, "' from ", db, " ...")
+
+              message("\n")
+      } else {
+          message("-> Starting proteome retrieval of '", organism, "' from ", db, " ...")
+          message("\n")
+      }
+
         if (is.element(db, c("refseq", "genbank"))) {
+          # TODO: Generalize this part like genome and gff
             # get Kingdom Assembly Summary file
             AssemblyFilesAllKingdoms <-
                 getKingdomAssemblySummary(db = db, skip_bacteria = skip_bacteria)
-            
+
             # test whether or not species is available
             if (!suppressMessages(is.genome.available(organism = organism, db = db, skip_bacteria = skip_bacteria))){
                     message(
@@ -111,26 +117,26 @@ getProteome <-
             if (!file.exists(path)) {
                 dir.create(path, recursive = TRUE)
             }
-            
-            organism_name <- assembly_accession <- taxid <- 
+
+            organism_name <- assembly_accession <- taxid <-
                 refseq_category <- version_status <- ftp_path <- NULL
             organism <-
                 stringr::str_replace_all(organism, "\\(", "")
             organism <-
                 stringr::str_replace_all(organism, "\\)", "")
-            
+
             if (reference) {
                 if (!is.taxid(organism)) {
                     FoundOrganism <-
                         dplyr::filter(
                             AssemblyFilesAllKingdoms,
-                            stringr::str_detect(organism_name, organism) | 
+                            stringr::str_detect(organism_name, organism) |
                                 stringr::str_detect(assembly_accession, organism),
                             ((refseq_category == "representative genome") |
                                  (refseq_category == "reference genome")
                             ),
                             (version_status == "latest"), !is.na(ftp_path)
-                        ) 
+                        )
                 } else {
                     FoundOrganism <-
                         dplyr::filter(
@@ -149,17 +155,17 @@ getProteome <-
                             stringr::str_detect(organism_name, organism) |
                                 stringr::str_detect(assembly_accession, organism),
                             (version_status == "latest"), !is.na(ftp_path)
-                        ) 
+                        )
                 } else {
                     FoundOrganism <-
                         dplyr::filter(
                             AssemblyFilesAllKingdoms,
                             taxid == as.integer(organism),
                             (version_status == "latest"), !is.na(ftp_path)
-                        ) 
+                        )
                 }
             }
-            
+
             if (nrow(FoundOrganism) == 0) {
                 message(
                     paste0(
@@ -181,10 +187,10 @@ getProteome <-
                     )
                     FoundOrganism <- FoundOrganism[1, ]
                 }
-                
+
                 organism <-
                     stringr::str_replace_all(organism, " ", "_")
-                
+
                 download_url <-
                     paste0(FoundOrganism$ftp_path,
                            "/",
@@ -192,24 +198,24 @@ getProteome <-
                                basename(FoundOrganism$ftp_path),
                                "_protein.faa.gz"
                            ))
-                
+
                 local.org <-
                     stringr::str_replace_all(organism, "-", "_")
                 local.org <-
                     stringr::str_replace_all(organism, "\\/", "_")
-                
+
                 # if (!exists.ftp.file(url = paste0(FoundOrganism$ftp_path, "/"),
                 #                      file.path = download_url)) {
                 #     message(
-                #         "Unfortunately no proteome file could be found 
+                #         "Unfortunately no proteome file could be found
                 #         for organism '",
                 #         organism,
-                #         "'. Thus, the download of this organism has 
+                #         "'. Thus, the download of this organism has
                 #         been omitted."
                 #     )
                 #     return(FALSE)
                 # }
-                # 
+                #
                 if (nrow(FoundOrganism) == 1) {
                     if (file.exists(file.path(
                         path,
@@ -230,23 +236,23 @@ getProteome <-
                                     download_url,
                                     destfile = file.path(
                                         path,
-                                        paste0(local.org, "_protein_", 
+                                        paste0(local.org, "_protein_",
                                                db, ".faa.gz")
                                     ),
                                     mode = "wb"
                                 )
                             )
-                            
+
                             message("-> Proteome download of ", organism, " is completed!")
-                                
+
                             # download md5checksum file for organism of interest
                             custom_download(
                             paste0(FoundOrganism$ftp_path,"/md5checksums.txt"),
-                                file.path(path, 
+                                file.path(path,
                                         paste0(local.org, "_md5checksums.txt")),
                                 mode = "wb"
                             )
-                            
+
                         }, error = function(e){
                           message(
                             "The download session seems to have timed out at the FTP site '",
@@ -257,30 +263,30 @@ getProteome <-
                           return("Not available")
                         })
                     }
-                      
+
                             # test check sum
-                            md5_file_path <- file.path(path, 
-                                                       paste0(local.org, 
+                            md5_file_path <- file.path(path,
+                                                       paste0(local.org,
                                                         "_md5checksums.txt"))
                             md5_file <-
                                 read_md5file(md5_file_path)
-                            
+
                             file_name <- NULL
-                            
+
                             md5_sum <- dplyr::filter(md5_file,
                                             file_name == paste0("./", paste0(
                                             basename(FoundOrganism$ftp_path),
                                                 "_protein.faa.gz"
                                             )))$md5
-                            
+
                             # check if md5 info is available
                             if (!is.character(md5_sum)){
-                            message("-> Checking md5 hash of file: ", 
+                            message("-> Checking md5 hash of file: ",
                                     file.path(
                                       path,
                                       paste0(local.org, "_protein_", db, ".faa.gz")
                                     ), " (md5: ", md5_sum ,")", " ...")
-                            
+
                             if (!(tools::md5sum(file.path(
                                 path,
                                 paste0(local.org, "_protein_", db, ".faa.gz")
@@ -296,10 +302,10 @@ getProteome <-
                                 )
                             unlink(md5_file_path)
                 message("-> The md5 hash of file '", md5_file_path, "' matches!")
-          }             
-                        
-          
-                    
+          }
+
+
+
                     docFile(
                         file.name = paste0(local.org, "_protein.faa.gz"),
                         organism  = organism,
@@ -318,7 +324,7 @@ getProteome <-
                         seq_rel_date = FoundOrganism$seq_rel_date,
                         submitter = FoundOrganism$submitter
                     )
-                    
+
                     doc <- tibble::tibble(
                         file_name = paste0(ifelse(is.taxid(organism), paste0("taxid_", local.org), local.org), "_genomic_", db,
                                            ".fna.gz"),
@@ -337,11 +343,11 @@ getProteome <-
                         genome_rep = FoundOrganism$genome_rep,
                         seq_rel_date = FoundOrganism$seq_rel_date,
                         submitter = FoundOrganism$submitter
-                        
+
                     )
-                    
+
                     readr::write_tsv(doc, file = file.path(path,paste0("doc_",local.org,"_db_",db,".tsv")))
-                    
+
                     if (!gunzip) {
                             message(
                                     paste0(
@@ -355,9 +361,9 @@ getProteome <-
                                     )
                             )
                       please_cite_biomartr(mute_citation = mute_citation)
-                            
+
                     }
-                    
+
                     if (gunzip) {
                             message(
                                     paste0(
@@ -372,7 +378,7 @@ getProteome <-
                             )
                       please_cite_biomartr(mute_citation = mute_citation)
                     }
-                    
+
                     if (gunzip) {
                             message("-> Unzipping downloaded file ...")
                             R.utils::gunzip(file.path(path,
@@ -384,7 +390,7 @@ getProteome <-
                             return(file.path(path,
                                              paste0(local.org, "_protein_", db, ".faa.gz")))
                     }
-                    
+
                 } else {
                     message(
                         "Something went wrong when trying to download file: ",
@@ -394,359 +400,26 @@ getProteome <-
                 }
             }
         }
-        
-        if (db == "ensembl") {
-            # create result folder
-            if (!file.exists(path)) {
-                dir.create(path, recursive = TRUE)
-            }
-            
+
+        if (db %in% c("ensembl", "ensemblgenomes")) {
             # download proteome sequence from ENSEMBL
-                proteome.path <-
-                        getENSEMBL.Seq(
-                                organism,
-                                type = "pep",
-                                id.type = "all",
-                                release = release,
-                                path = path
-                        )
-            
-            if (is.logical(proteome.path[1])) {
-                if (!proteome.path[1])
-                    return(FALSE)
-            } else {
-                
-                taxon_id <- assembly <- name <- accession <- NULL
-                
-                ensembl_summary <-
-                    suppressMessages(is.genome.available(
-                        organism = organism,
-                        db = "ensembl",
-                        details = TRUE
-                    ))
-                
-                if (nrow(ensembl_summary) > 1) {
-                    if (is.taxid(organism)) {
-                        ensembl_summary <-
-                            dplyr::filter(ensembl_summary, taxon_id == as.integer(organism), !is.na(assembly))
-                    } else {
-                        
-                        ensembl_summary <-
-                            dplyr::filter(
-                                ensembl_summary,
-                                (name == stringr::str_to_lower(stringr::str_replace_all(organism, " ", "_"))) |
-                                    (accession == organism),
-                                    !is.na(assembly)
-                            )
-                    }
-                }
-                
-                
-                new.organism <- ensembl_summary$name[1]
-                new.organism <-
-                    paste0(
-                        stringr::str_to_upper(stringr::str_sub(new.organism, 1, 1)),
-                        stringr::str_sub(new.organism, 2, nchar(new.organism))
-                    )     
-                
-                url_api <- paste0(
-                    "http://rest.ensembl.org/info/assembly/",
-                    new.organism,
-                    "?content-type=application/json"
-                )
-                
-                # choose only first entry if not specified otherwise
-                if (length(url_api) > 1)
-                    url_api <- url_api[1]
-                
-                if (curl::curl_fetch_memory(url_api)$status_code != 200) {
-                    message("The API call '",url_api,"' did not work. This might be due to a non-existing organism that you specified or a corrupted internet or firewall connection.")
-                    return("Not available")
-                }
-                
-                # retrieve information from API
-                json.qry.info <- jsonlite::fromJSON(url_api)
-                
-                # generate Proteome documentation
-                sink(file.path(
-                    path,
-                    paste0("doc_", new.organism, "_db_", db, ".txt")
-                ))
-                
-                cat(paste0("File Name: ", proteome.path[1]))
-                cat("\n")
-                cat(paste0("Download Path: ", proteome.path[2]))
-                cat("\n")
-                cat(paste0("Organism Name: ", new.organism))
-                cat("\n")
-                cat(paste0("Database: ", db))
-                cat("\n")
-                cat(paste0("Download_Date: ", date()))
-                cat("\n")
-                cat(paste0("assembly_name: ", ifelse(!is.null(json.qry.info$assembly_name), json.qry.info$assembly_name, "none")))
-                cat("\n")
-                cat(paste0("assembly_date: ", ifelse(!is.null(json.qry.info$assembly_date), json.qry.info$assembly_date, "none")))
-                cat("\n")
-                cat(
-                        paste0(
-                                "genebuild_last_geneset_update: ",
-                                ifelse(!is.null(json.qry.info$genebuild_last_geneset_update), json.qry.info$genebuild_last_geneset_update, "none")
-                        )
-                )
-                cat("\n")
-                cat(paste0(
-                        "assembly_accession: ",
-                        ifelse(!is.null(json.qry.info$assembly_accession), json.qry.info$assembly_accession, "none")
-                ))
-                cat("\n")
-                cat(
-                        paste0(
-                                "genebuild_initial_release_date: ",
-                                ifelse(!is.null(json.qry.info$genebuild_initial_release_date), json.qry.info$genebuild_initial_release_date, "none")
-                        )
-                )
-                
-                sink()
-                
-                doc <- tibble::tibble(
-                        file_name = proteome.path[1],
-                        download_path = proteome.path[2],
-                        organism = new.organism,
-                        database = db,
-                        download_data = date(),
-                        assembly_name = ifelse(!is.null(json.qry.info$assembly_name), json.qry.info$assembly_name, "none"),
-                        assembly_date = ifelse(!is.null(json.qry.info$assembly_date), json.qry.info$assembly_date, "none"),
-                        genebuild_last_geneset_update = ifelse(!is.null(json.qry.info$genebuild_last_geneset_update), json.qry.info$genebuild_last_geneset_update, "none"), 
-                        assembly_accession = ifelse(!is.null(json.qry.info$assembly_accession), json.qry.info$assembly_accession, "none"),
-                        genebuild_initial_release_date = ifelse(!is.null(json.qry.info$genebuild_initial_release_date), json.qry.info$genebuild_initial_release_date, "none")
-                        
-                )
-                
-                readr::write_tsv(doc, file = file.path(
-                        path,
-                        paste0("doc_", new.organism, "_db_", db, ".tsv"))
-                )
-                
-                if (!gunzip) {
-                        message(
-                                paste0(
-                                        "The proteome of '",
-                                        ensembl_summary$display_name[1],
-                                        "' has been downloaded to '",
-                                        path,
-                                        "' and has been named '",
-                                        basename(proteome.path[1]),
-                                        "'."
-                                )
-                        )
-                  please_cite_biomartr(mute_citation = mute_citation)
-                }
-                
-                if (gunzip) {
-                        message(
-                                paste0(
-                                        "-> The proteome of '",
-                                        ensembl_summary$display_name[1],
-                                        "' has been downloaded to '",
-                                        path,
-                                        "' and has been named '",
-                                        basename(unlist(stringr::str_replace(proteome.path[1], "[.]gz", ""))),
-                                        "'."
-                                )
-                        )
-                  please_cite_biomartr(mute_citation = mute_citation)
-                }
-                
-                if (gunzip) {
-                        message("-> Unzipping downloaded file ...")
-                        R.utils::gunzip(proteome.path[1], destname = unlist(stringr::str_replace(proteome.path[1], "[.]gz", "")))
-                        return(unlist(stringr::str_replace(proteome.path[1], "[.]gz", "")))
-                } else {
-                        return(proteome.path[1])
-                }
-            }
+            proteome.path <- getENSEMBL.Seq(organism, type = "pep",
+                                            id.type = "all",
+                                            release = release,
+                                            path = path)
+            return(ensembl_download_post_processing(proteome.path, organism,
+                                                    format = "pep.fa",
+                                                    remove_annotation_outliers,
+                                                    gunzip,
+                                                    mute_citation = mute_citation))
+
+
         }
-        
-        if (db == "ensemblgenomes") {
-            # create result folder
-            if (!file.exists(path)) {
-                dir.create(path, recursive = TRUE)
-            }
-            
-            # download proteome sequence from ENSEMBLGENOMES
-                proteome.path <-
-                        getENSEMBLGENOMES.Seq(
-                                organism,
-                                type = "pep",
-                                id.type = "all",
-                                release = release,
-                                path = path
-                        )
-            
-            if (is.logical(proteome.path[1])) {
-                if (!proteome.path[1])
-                    return(FALSE)
-            } else {
-                
-                taxon_id <- assembly <- name <- accession <- NULL
-                
-                ensembl_summary <-
-                    suppressMessages(is.genome.available(
-                        organism = organism,
-                        db = "ensemblgenomes",
-                        details = TRUE
-                    ))
-                
-                if (nrow(ensembl_summary) > 1) {
-                    if (is.taxid(organism)) {
-                        ensembl_summary <-
-                            dplyr::filter(ensembl_summary, taxon_id == as.integer(organism), !is.na(assembly))
-                    } else {
-                        
-                        ensembl_summary <-
-                            dplyr::filter(
-                                ensembl_summary,
-                                (name == stringr::str_to_lower(stringr::str_replace_all(organism, " ", "_"))) |
-                                    (accession == organism),
-                                    !is.na(assembly)
-                            )
-                    }
-                }
-                
-                new.organism <- ensembl_summary$name[1]
-                new.organism <-
-                    paste0(
-                        stringr::str_to_upper(stringr::str_sub(new.organism, 1, 1)),
-                        stringr::str_sub(new.organism, 2, nchar(new.organism))
-                    ) 
-                
-                rest_url <- paste0(
-                    "http://rest.ensembl.org/info/assembly/",
-                    new.organism,
-                    "?content-type=application/json"
-                )
-                
-                if (curl::curl_fetch_memory(rest_url)$status_code != 200) {
-                    message(
-                        "The url: '",rest_url,"' cannot be reached. This might be due to a connection issue or incorrect url path (e.g. not valid organism name).")
-                        return(FALSE)
-                }
-                
-                # test proper API access
-              json.qry.info <-
-                    jsonlite::fromJSON(rest_url)
-              
-                # generate Proteome documentation
-                sink(file.path(
-                        path,
-                        paste0("doc_", new.organism, "_db_", db, ".txt")
-                ))
-                
-                cat(paste0("File Name: ", proteome.path[1]))
-                cat("\n")
-                cat(paste0("Download Path: ", proteome.path[2]))
-                cat("\n")
-                cat(paste0("Organism Name: ", new.organism))
-                cat("\n")
-                cat(paste0("Database: ", db))
-                cat("\n")
-                cat(paste0("Download_Date: ", date()))
-                cat("\n")
-                cat(paste0("assembly_name: ", ifelse(!is.null(json.qry.info$assembly_name), json.qry.info$assembly_name, "none")))
-                cat("\n")
-                cat(paste0("assembly_date: ", ifelse(!is.null(json.qry.info$assembly_date), json.qry.info$assembly_date, "none")))
-                cat("\n")
-                cat(
-                        paste0(
-                                "genebuild_last_geneset_update: ",
-                                ifelse(!is.null(json.qry.info$genebuild_last_geneset_update), json.qry.info$genebuild_last_geneset_update, "none")
-                        )
-                )
-                cat("\n")
-                cat(paste0(
-                        "assembly_accession: ",
-                        ifelse(!is.null(json.qry.info$assembly_accession), json.qry.info$assembly_accession, "none")
-                ))
-                cat("\n")
-                cat(
-                        paste0(
-                                "genebuild_initial_release_date: ",
-                                ifelse(!is.null(json.qry.info$genebuild_initial_release_date), json.qry.info$genebuild_initial_release_date, "none")
-                        )
-                )
-                
-                sink()
-                
-                doc <- tibble::tibble(
-                        file_name = proteome.path[1],
-                        download_path = proteome.path[2],
-                        organism = new.organism,
-                        database = db,
-                        download_data = date(),
-                        assembly_name = ifelse(!is.null(json.qry.info$assembly_name), json.qry.info$assembly_name, "none"),
-                        assembly_date = ifelse(!is.null(json.qry.info$assembly_date), json.qry.info$assembly_date, "none"),
-                        genebuild_last_geneset_update = ifelse(!is.null(json.qry.info$genebuild_last_geneset_update), json.qry.info$genebuild_last_geneset_update, "none"),
-                        assembly_accession = ifelse(!is.null(json.qry.info$assembly_accession), json.qry.info$assembly_accession, "none"), 
-                        genebuild_initial_release_date = ifelse(!is.null(json.qry.info$genebuild_initial_release_date), json.qry.info$genebuild_initial_release_date, "none")
-                        
-                )
-                
-                readr::write_tsv(doc, file = file.path(
-                        path,
-                        paste0("doc_", new.organism, "_db_", db, ".tsv"))
-                )
-                
-                if (!gunzip) {
-                        message(
-                                paste0(
-                                        "The proteome of '",
-                                        ensembl_summary$display_name,
-                                        "' has been downloaded to '",
-                                        path,
-                                        "' and has been named '",
-                                        basename(proteome.path[1]),
-                                        "'."
-                                )
-                        )
-                  please_cite_biomartr(mute_citation = mute_citation)
-                }
-                
-                if (gunzip) {
-                        message(
-                                paste0(
-                                        "The proteome of '",
-                                        ensembl_summary$display_name,
-                                        "' has been downloaded to '",
-                                        path,
-                                        "' and has been named '",
-                                        basename(unlist(stringr::str_replace(proteome.path[1], "[.]gz", ""))),
-                                        "'."
-                                )
-                        )
-                  please_cite_biomartr(mute_citation = mute_citation)
-                }
-                
-                if (gunzip) {
-                        message("Unzipping downloaded file ...")
-                        R.utils::gunzip(proteome.path[1], destname = unlist(stringr::str_replace(proteome.path[1], "[.]gz", "")))
-                        please_cite_biomartr(mute_citation = mute_citation)
-                        return(unlist(stringr::str_replace(proteome.path[1], "[.]gz", "")))
-                } else {
-                  please_cite_biomartr(mute_citation = mute_citation)
-                  
-                        return(proteome.path[1])
-                }
-            }
-        }
-        
+
         if (db == "uniprot") {
-                
-                if (!file.exists(path)) {
-                        dir.create(path, recursive = TRUE)
-                }
-                
-                getUniProtSeq(organism = organism, path = path, update = TRUE, gunzip = gunzip)
-                please_cite_biomartr(mute_citation = mute_citation)
+            getUniProtSeq(organism = organism, path = path, update = TRUE,
+                          gunzip = gunzip)
+            please_cite_biomartr(mute_citation = mute_citation)
         }
     }
 

--- a/tests/testthat/test-getMetaGenomeSummary.R
+++ b/tests/testthat/test-getMetaGenomeSummary.R
@@ -3,5 +3,5 @@ context("Test: getMetaGenomeSummary()")
 test_that("The getMetaGenomeSummary() interface works properly..",{
     skip_on_cran()
     skip_on_travis()
-    expect_output(getMetaGenomeSummary())
+    expect_false(nrow(getMetaGenomeSummary()) == 0)
 })

--- a/tests/testthat/test-getProteome.R
+++ b/tests/testthat/test-getProteome.R
@@ -4,26 +4,27 @@ test_that("The getProteome() interface to NCBI RefSeq works properly (including 
     skip_on_cran()
     skip_on_travis()
     # test proper download
-    Proteome <-
+    out1 <-
         read_proteome(
             getProteome(
                 db       = "refseq",
                 organism = "Saccharomyces cerevisiae",
-                path     = tempdir()
+                path     = tempdir(), mute_citation = TRUE
             ),
             format = "fasta"
         )
-    
+
     # test proper use of internal referece files when command is repeated
-    Proteome <-
+    out2 <-
         read_proteome(
             getProteome(
                 db       = "refseq",
                 organism = "Saccharomyces cerevisiae",
-                path     = tempdir()
+                path     = tempdir(), mute_citation = TRUE
             ),
             format = "fasta"
         )
+    expect_false(length(out1) != length(out2) | length(out1) == 0)
 })
 
 
@@ -31,24 +32,25 @@ test_that("The getProteome() interface to NCBI RefSeq works properly using taxid
     skip_on_cran()
     skip_on_travis()
     # test proper download
-        read_proteome(
+    out1 <-   read_proteome(
             getProteome(
                 db       = "refseq",
                 organism = "559292",
-                path     = tempdir()
+                path     = tempdir(), mute_citation = TRUE
             ),
             format = "fasta"
         )
-    
+
     # test proper use of internal referece files when command is repeated
-        read_proteome(
+    out2 <-  read_proteome(
             getProteome(
                 db       = "refseq",
                 organism = "559292",
-                path     = tempdir()
+                path     = tempdir(), mute_citation = TRUE
             ),
             format = "fasta"
         )
+        expect_false(length(out1) != length(out2) | length(out1) == 0)
 })
 
 
@@ -56,49 +58,50 @@ test_that("The getProteome() interface to NCBI RefSeq works properly using acces
     skip_on_cran()
     skip_on_travis()
     # test proper download
-    read_proteome(
+    out1 <- read_proteome(
         getProteome(
             db       = "refseq",
             organism = "GCF_000146045.2",
-            path     = tempdir()
+            path     = tempdir(), mute_citation = TRUE
         ),
         format = "fasta"
     )
-    
+
     # test proper use of internal referece files when command is repeated
-    read_proteome(
+    out2 <- read_proteome(
         getProteome(
             db       = "refseq",
             organism = "GCF_000146045.2",
-            path     = tempdir()
+            path     = tempdir(), mute_citation = TRUE
         ),
         format = "fasta"
     )
+    expect_false(length(out1) != length(out2) | length(out1) == 0)
 })
 
 test_that("The getProteome() interface to NCBI Genbank works properly (including repeating command)..", {
     skip_on_cran()
-    skip_on_travis() 
+    skip_on_travis()
     # test proper download from genbank
-        read_proteome(
+    out1 <-   read_proteome(
             getProteome(
                 db       = "genbank",
                 organism = "Saccharomyces cerevisiae",
-                path     = tempdir()
+                path     = tempdir(), mute_citation = TRUE
             ),
             format = "fasta"
         )
-    
+
     # test proper use of internal referece files when command is repeated
-        read_proteome(
+    out2 <-   read_proteome(
             getProteome(
                 db       = "genbank",
                 organism = "Saccharomyces cerevisiae",
-                path     = tempdir()
+                path     = tempdir(), mute_citation = TRUE
             ),
             format = "fasta"
         )
-    
+        expect_false(length(out1) != length(out2) | length(out1) == 0)
 })
 
 
@@ -106,24 +109,25 @@ test_that("The getProteome() interface to NCBI Genbank works properly using taxi
     skip_on_cran()
     skip_on_travis()
     # test proper download
-    read_proteome(
+    out1 <- read_proteome(
         getProteome(
             db       = "genbank",
             organism = "559292",
-            path     = tempdir()
+            path     = tempdir(), mute_citation = TRUE
         ),
         format = "fasta"
     )
-    
+
     # test proper use of internal referece files when command is repeated
-    read_proteome(
+    out2 <- read_proteome(
         getProteome(
             db       = "genbank",
             organism = "559292",
-            path     = tempdir()
+            path     = tempdir(), mute_citation = TRUE
         ),
         format = "fasta"
     )
+    expect_false(length(out1) != length(out2) | length(out1) == 0)
 })
 
 
@@ -131,91 +135,110 @@ test_that("The getProteome() interface to NCBI Genbank works properly using acce
     skip_on_cran()
     skip_on_travis()
     # test proper download
-    read_proteome(
+    out1 <- read_proteome(
         getProteome(
             db       = "genbank",
             organism = "GCA_000146045.2",
-            path     = tempdir()
+            path     = tempdir(), mute_citation = TRUE
         ),
         format = "fasta"
     )
-    
+
     # test proper use of internal referece files when command is repeated
-    read_proteome(
+    out2 <- read_proteome(
         getProteome(
             db       = "genbank",
             organism = "GCA_000146045.2",
-            path     = tempdir()
+            path     = tempdir(), mute_citation = TRUE
         ),
         format = "fasta"
     )
+    expect_false(length(out1) != length(out2) | length(out1) == 0)
 })
 
 test_that("The getProteome() interface to Ensembl works properly (including repeating command)..", {
     skip_on_cran()
     skip_on_travis()
-        read_proteome(
+    out1 <- read_proteome(
             getProteome(
                 db       = "ensembl",
                 organism = "Saccharomyces cerevisiae",
-                path     = tempdir()
+                path     = tempdir(), mute_citation = TRUE
             ),
             format = "fasta"
         )
-    
-        read_proteome(
+
+    out2 <-  read_proteome(
             getProteome(
                 db       = "ensembl",
                 organism = "Saccharomyces cerevisiae",
-                path     = tempdir()
+                path     = tempdir(), mute_citation = TRUE
             ),
             format = "fasta"
         )
+        expect_false(length(out1) != length(out2) | length(out1) == 0)
 })
 
 test_that("The getProteome() interface to Ensembl works properly using taxid (including repeating command)..", {
     skip_on_cran()
     skip_on_travis()
-    read_proteome(
+    out1 <- read_proteome(
         getProteome(
             db       = "ensembl",
             organism = "4932",
-            path     = tempdir()
+            path     = tempdir(), mute_citation = TRUE
         ),
         format = "fasta"
     )
-    
-    read_proteome(
+
+    out2 <- read_proteome(
         getProteome(
             db       = "ensembl",
             organism = "4932",
-            path     = tempdir()
+            path     = tempdir(), mute_citation = TRUE
         ),
         format = "fasta"
     )
+    expect_false(length(out1) != length(out2) | length(out1) == 0)
 })
 
 
 test_that("The getProteome() interface to Ensembl works properly using accession ids (including repeating command)..", {
     skip_on_cran()
     skip_on_travis()
-    read_proteome(
+    out1 <- read_proteome(
         getProteome(
             db       = "ensembl",
             organism = "GCA_000146045.2",
-            path     = tempdir()
+            path     = tempdir(), mute_citation = TRUE
         ),
         format = "fasta"
     )
-    
-    read_proteome(
+
+    out2 <- read_proteome(
         getProteome(
             db       = "ensembl",
             organism = "GCA_000146045.2",
-            path     = tempdir()
+            path     = tempdir(), mute_citation = TRUE
         ),
         format = "fasta"
     )
+    expect_false(length(out1) != length(out2) | length(out1) == 0)
 })
+
+test_that("The getProteome() interface to Ensembl works properly (For organisms with collections)..", {
+  skip_on_cran()
+  skip_on_travis()
+
+  out <- getProteome(
+    db       = "ensembl",
+    organism = "Escherichia coli",
+    path     = tempdir(), mute_citation = TRUE
+  )
+
+  expect_false(is.logical(out))
+})
+
+
 
 


### PR DESCRIPTION
Generalized getProteom to the new format for ensembl. 

Fix for https://github.com/ropensci/biomartr/issues/84.

EnsemblGenomes species now work for proteome, added also a new test to verify it works. 