### PR TITLE
Fixed bug for ensembl ftp base url path for windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: biomartr
 Title: Genomic Data Retrieval
-Version: 1.0.7.9000
+Version: 1.0.8.9000
 Authors@R: c(person("Hajk-Georg", "Drost",
                 role = c("aut", "cre"),
                 email = "hajk-georg.drost@tuebingen.mpg.de",

--- a/R/get.ensembl.info.R
+++ b/R/get.ensembl.info.R
@@ -169,8 +169,8 @@ ensembl_ftp_server_url_format <- function(division, release = NULL, format) {
 }
 
 ensembl_ftp_server_url_format_full <- function(division, release = NULL, format) {
-  file.path(ensembl_ftp_server_url(division),
-            ensembl_ftp_server_url_format(division, release, format))
+  paste0(ensembl_ftp_server_url(division), "/",
+         ensembl_ftp_server_url_format(division, release, format))
 }
 
 ensembl_ftp_server_url_release_style_fasta <- function(division, release = NULL) {
@@ -183,13 +183,13 @@ ensembl_ftp_server_url_release_style_gtf <- function(division, release = NULL, f
 
 
 ensembl_ftp_server_url_fasta <- function(division, release = NULL) {
-  file.path(ensembl_ftp_server_url(division),
-            ensembl_ftp_server_url_release_style_fasta(division, release))
+  paste0(ensembl_ftp_server_url(division), "/",
+         ensembl_ftp_server_url_release_style_fasta(division, release))
 }
 
 ensembl_ftp_server_url_gtf <- function(division = "EnsemblVertebrates",
                                        release = NULL, format = "gtf") {
-  file.path(ensembl_ftp_server_url(division),
-            ensembl_ftp_server_url_release_style_gtf(division, release, format))
+  paste0(ensembl_ftp_server_url(division), "/",
+         ensembl_ftp_server_url_release_style_gtf(division, release, format))
 }
 


### PR DESCRIPTION
A bug for windows, ensembl paths did not work at all, since file.path function removes trailing slashes there.
It now uses paste0, which is consistent on all OS. 
I also bumped version, so you can push this version to cran. 