### PR TITLE
Added GTF support for refseq/genbank

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: biomartr
 Title: Genomic Data Retrieval
-Version: 1.0.9
+Version: 1.0.10
 Authors@R: c(person("Hajk-Georg", "Drost",
                 role = c("aut", "cre"),
                 email = "hajk-georg.drost@tuebingen.mpg.de",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# [biomartr 1.0.10](https://github.com/ropensci/biomartr/releases/tag/v1.0.10)
+
+### New features
+
+#### GTF support for refseq and genbank
+- Since refseq and genbank now supports gtf, we allow it in getGFF/getFFF
+
 # [biomartr 1.0.9](https://github.com/ropensci/biomartr/releases/tag/v1.0.9)
 
 ### New features

--- a/R/Refseq_Genbank_ftp_generics.R
+++ b/R/Refseq_Genbank_ftp_generics.R
@@ -82,9 +82,11 @@ ftp_url_refseq_genbank <- function(assembly, type) {
 
   if (type == "genome") {
     url <- paste0(stem_url, "_genomic.fna.gz")
-  } else if (type == "gff") {
+  } else if (type %in% c("gff", "gff3")) {
     url <- paste0(stem_url, "_genomic.gff.gz")
-  } else if (type == "cds") {
+  } else if (type == "gtf") {
+    url <- paste0(stem_url, "_genomic.gtf.gz")
+  }else if (type == "cds") {
     url <- paste0(stem_url, "_cds_from_genomic.fna.gz")
   } else if (type == "rna") {
     url <- paste0(stem_url, "_rna_from_genomic.fna.gz")
@@ -106,9 +108,11 @@ local_path_refseq_genbank <- function(path, local.org, db, type) {
 
   if (type == "genome") {
     local_file <- paste0(local_file, "_genomic_", db, ".fna.gz")
-  } else if (type == "gff") {
+  } else if (type %in% c("gff", "gff3")) {
     local_file <- paste0(local_file, "_genomic_", db, ".gff.gz")
-  } else if (type == "cds") {
+  } else if (type == "gtf") {
+    local_file <- paste0(local_file, "_genomic_", db, ".gtf.gz")
+  }else if (type == "cds") {
     local_file <- paste0(local_file, "_cds_from_genomic_", db, ".fna.gz")
   } else if (type == "rna") {
     local_file <- paste0(local_file, "_rna_from_genomic_", db, ".fna.gz")

--- a/R/getBioSet.R
+++ b/R/getBioSet.R
@@ -105,7 +105,9 @@ getBioSet <- function(db = "refseq",
 #' }
 #' @param type biological sequence type. (alternatives are: genome, gff, cds,
 #' rna, proteome, assembly_stats, repeat_masker, collection (all the others))
-#' @param reference a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.
+#' @param reference a logical value indicating whether or not a genome shall be a candidate for downloaded
+#'  if it isn't marked in the database as either a reference genome or a representative genome.
+#'  This is helpful if you don't want to allow "partial genomes" etc.
 #' @param release a numeric, the database release version of ENSEMBL (\code{db = "ensembl"}). Default is \code{release = NULL} meaning
 #' that the most recent database version is used. \code{release = 75} would for human would give the stable
 #' GRCh37 release in ensembl. Value must be > 46, since ensembl did not structure their data

--- a/R/getGFF.R
+++ b/R/getGFF.R
@@ -103,7 +103,7 @@ getGFF <- function(db = "refseq", organism, reference = FALSE,
 #' @export
 getGTF <-
   function(db = "ensembl",
-           organism,
+           organism, reference = FALSE,
            remove_annotation_outliers = FALSE,
            path = file.path("ensembl", "annotation"),
            release = NULL,
@@ -112,6 +112,7 @@ getGTF <-
       stop( "Please select one of the available data bases: db = 'ensembl'.", call. = FALSE)
     getGFF(db = "ensembl",
            organism,
+           reference = reference,
            remove_annotation_outliers = remove_annotation_outliers,
            path = path,
            release = release,

--- a/R/getGFF.R
+++ b/R/getGFF.R
@@ -62,7 +62,7 @@ getGFF <- function(db = "refseq", organism, reference = FALSE,
 
     if (is.element(db, c("refseq", "genbank"))) {
       info <- get_file_refseq_genbank(db, organism, reference, skip_bacteria,
-                                      release, gunzip, path, type = "gff")
+                                      release, gunzip, path, type = format)
       return(refseq_genbank_download_post_processing(info, organism, db, path,
                                                      gunzip,
                                                      remove_annotation_outliers,

--- a/R/getGFF.R
+++ b/R/getGFF.R
@@ -109,7 +109,8 @@ getGTF <-
            release = NULL,
            mute_citation = FALSE) {
     if (!is.element(db, c("ensembl", "refseq", "genbank")))
-      stop( "Please select one of the available data bases: db = 'ensembl'.", call. = FALSE)
+      stop( "Please select one of the available data bases: db = 'ensembl',",
+            "'refseq', 'genbank'.", call. = FALSE)
     getGFF(db = db,
            organism,
            reference = reference,

--- a/R/getGFF.R
+++ b/R/getGFF.R
@@ -108,9 +108,9 @@ getGTF <-
            path = file.path("ensembl", "annotation"),
            release = NULL,
            mute_citation = FALSE) {
-    if (!is.element(db, c("ensembl")))
+    if (!is.element(db, c("ensembl", "refseq", "genbank")))
       stop( "Please select one of the available data bases: db = 'ensembl'.", call. = FALSE)
-    getGFF(db = "ensembl",
+    getGFF(db = db,
            organism,
            reference = reference,
            remove_annotation_outliers = remove_annotation_outliers,

--- a/man/getBio.Rd
+++ b/man/getBio.Rd
@@ -41,7 +41,9 @@ there are three options to characterize an organism:
 \item{type}{biological sequence type. (alternatives are: genome, gff, cds,
 rna, proteome, assembly_stats, repeat_masker, collection (all the others))}
 
-\item{reference}{a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.}
+\item{reference}{a logical value indicating whether or not a genome shall be a candidate for downloaded
+if it isn't marked in the database as either a reference genome or a representative genome.
+This is helpful if you don't want to allow "partial genomes" etc.}
 
 \item{release}{a numeric, the database release version of ENSEMBL (\code{db = "ensembl"}). Default is \code{release = NULL} meaning
 that the most recent database version is used. \code{release = 75} would for human would give the stable

--- a/man/getBioSet.Rd
+++ b/man/getBioSet.Rd
@@ -45,7 +45,9 @@ Available options are
 \item \code{set_type = "collection"} (all the others)
 }}
 
-\item{reference}{a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.}
+\item{reference}{a logical value indicating whether or not a genome shall be a candidate for downloaded
+if it isn't marked in the database as either a reference genome or a representative genome.
+This is helpful if you don't want to allow "partial genomes" etc.}
 
 \item{release}{a numeric, the database release version of ENSEMBL (\code{db = "ensembl"}). Default is \code{release = NULL} meaning
 that the most recent database version is used. \code{release = 75} would for human would give the stable

--- a/man/getCDS.Rd
+++ b/man/getCDS.Rd
@@ -32,7 +32,9 @@ there are three options to characterize an organism:
 \item by \code{taxonomic identifier from NCBI Taxonomy}: e.g. \code{organism = "9606"} (= taxid of \code{Homo sapiens})
 }}
 
-\item{reference}{a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.}
+\item{reference}{a logical value indicating whether or not a genome shall be a candidate for downloaded
+if it isn't marked in the database as either a reference genome or a representative genome.
+This is helpful if you don't want to allow "partial genomes" etc.}
 
 \item{skip_bacteria}{Due to its enormous dataset size (> 700MB as of July 2023),
 the bacterial summary file will not be loaded by default anymore. If users

--- a/man/getCDSSet.Rd
+++ b/man/getCDSSet.Rd
@@ -26,7 +26,9 @@ shall be retrieved:
 \item{organisms}{a character vector storing the names of the organisms than shall be retrieved.
 There are three available options to characterize an organism:}
 
-\item{reference}{a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.}
+\item{reference}{a logical value indicating whether or not a genome shall be a candidate for downloaded
+if it isn't marked in the database as either a reference genome or a representative genome.
+This is helpful if you don't want to allow "partial genomes" etc.}
 
 \item{release}{a numeric, the database release version of ENSEMBL (\code{db = "ensembl"}). Default is \code{release = NULL} meaning
 that the most recent database version is used. \code{release = 75} would for human would give the stable

--- a/man/getCollection.Rd
+++ b/man/getCollection.Rd
@@ -35,7 +35,9 @@ there are three options to characterize an organism:
 \item by \code{taxonomic identifier from NCBI Taxonomy}: e.g. \code{organism = "9606"} (= taxid of \code{Homo sapiens})
 }}
 
-\item{reference}{a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.}
+\item{reference}{a logical value indicating whether or not a genome shall be a candidate for downloaded
+if it isn't marked in the database as either a reference genome or a representative genome.
+This is helpful if you don't want to allow "partial genomes" etc.}
 
 \item{skip_bacteria}{Due to its enormous dataset size (> 700MB as of July 2023),
 the bacterial summary file will not be loaded by default anymore. If users

--- a/man/getCollectionSet.Rd
+++ b/man/getCollectionSet.Rd
@@ -29,7 +29,9 @@ shall be retrieved:
 \item{organisms}{a character vector storing the names of the organisms than shall be retrieved.
 There are three available options to characterize an organism:}
 
-\item{reference}{a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.}
+\item{reference}{a logical value indicating whether or not a genome shall be a candidate for downloaded
+if it isn't marked in the database as either a reference genome or a representative genome.
+This is helpful if you don't want to allow "partial genomes" etc.}
 
 \item{release}{a numeric, the database release version of ENSEMBL (\code{db = "ensembl"}). Default is \code{release = NULL} meaning
 that the most recent database version is used. \code{release = 75} would for human would give the stable

--- a/man/getGFF.Rd
+++ b/man/getGFF.Rd
@@ -94,6 +94,9 @@ For ensembl it fetches overview per type from the rest API:
 }
 \examples{
 \dontrun{
+# Simple and small yeast download from refseq
+ getGFF( db       = "refseq", organism = "Saccharomyces cerevisiae",
+  path = tempdir(), mute_citation = TRUE)
 # download the annotation of Arabidopsis thaliana from refseq
 # and store the corresponding genome file in '_ncbi_downloads/annotation'
 Athal_gff <- getGFF( db       = "refseq",

--- a/man/getGFF.Rd
+++ b/man/getGFF.Rd
@@ -34,7 +34,9 @@ there are three options to characterize an organism:
 \item by \code{taxonomic identifier from NCBI Taxonomy}: e.g. \code{organism = "9606"} (= taxid of \code{Homo sapiens})
 }}
 
-\item{reference}{a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.}
+\item{reference}{a logical value indicating whether or not a genome shall be a candidate for downloaded
+if it isn't marked in the database as either a reference genome or a representative genome.
+This is helpful if you don't want to allow "partial genomes" etc.}
 
 \item{skip_bacteria}{Due to its enormous dataset size (> 700MB as of July 2023),
 the bacterial summary file will not be loaded by default anymore. If users

--- a/man/getGFFSet.Rd
+++ b/man/getGFFSet.Rd
@@ -30,7 +30,9 @@ shall be retrieved:
 \item{organisms}{a character vector storing the names of the organisms than shall be retrieved.
 There are three available options to characterize an organism:}
 
-\item{reference}{a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.}
+\item{reference}{a logical value indicating whether or not a genome shall be a candidate for downloaded
+if it isn't marked in the database as either a reference genome or a representative genome.
+This is helpful if you don't want to allow "partial genomes" etc.}
 
 \item{release}{a numeric, the database release version of ENSEMBL (\code{db = "ensembl"}). Default is \code{release = NULL} meaning
 that the most recent database version is used. \code{release = 75} would for human would give the stable

--- a/man/getGTF.Rd
+++ b/man/getGTF.Rd
@@ -7,6 +7,7 @@
 getGTF(
   db = "ensembl",
   organism,
+  reference = FALSE,
   remove_annotation_outliers = FALSE,
   path = file.path("ensembl", "annotation"),
   release = NULL,
@@ -29,6 +30,10 @@ there are three options to characterize an organism:
 \item by \code{database specific accession identifier}: e.g. \code{organism = "GCF_000001405.37"} (= NCBI RefSeq identifier for \code{Homo sapiens})
 \item by \code{taxonomic identifier from NCBI Taxonomy}: e.g. \code{organism = "9606"} (= taxid of \code{Homo sapiens})
 }}
+
+\item{reference}{a logical value indicating whether or not a genome shall be a candidate for downloaded
+if it isn't marked in the database as either a reference genome or a representative genome.
+This is helpful if you don't want to allow "partial genomes" etc.}
 
 \item{remove_annotation_outliers}{shall outlier lines be removed from the input \code{annotation_file}?
 If yes, then the initial \code{annotation_file} will be overwritten and the removed outlier lines will be stored at \code{\link{tempdir}}

--- a/man/getGenome.Rd
+++ b/man/getGenome.Rd
@@ -34,7 +34,9 @@ there are three options to characterize an organism:
 \item by \code{taxonomic identifier from NCBI Taxonomy}: e.g. \code{organism = "9606"} (= taxid of \code{Homo sapiens})
 }}
 
-\item{reference}{a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.}
+\item{reference}{a logical value indicating whether or not a genome shall be a candidate for downloaded
+if it isn't marked in the database as either a reference genome or a representative genome.
+This is helpful if you don't want to allow "partial genomes" etc.}
 
 \item{skip_bacteria}{Due to its enormous dataset size (> 700MB as of July 2023),
 the bacterial summary file will not be loaded by default anymore. If users

--- a/man/getGenomeSet.Rd
+++ b/man/getGenomeSet.Rd
@@ -29,7 +29,9 @@ shall be retrieved:
 \item{organisms}{a character vector storing the names of the organisms than shall be retrieved.
 There are three available options to characterize an organism:}
 
-\item{reference}{a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.}
+\item{reference}{a logical value indicating whether or not a genome shall be a candidate for downloaded
+if it isn't marked in the database as either a reference genome or a representative genome.
+This is helpful if you don't want to allow "partial genomes" etc.}
 
 \item{release}{a numeric, the database release version of ENSEMBL (\code{db = "ensembl"}). Default is \code{release = NULL} meaning
 that the most recent database version is used. \code{release = 75} would for human would give the stable

--- a/man/getProteome.Rd
+++ b/man/getProteome.Rd
@@ -33,7 +33,9 @@ there are three options to characterize an organism:
 \item by \code{taxonomic identifier from NCBI Taxonomy}: e.g. \code{organism = "9606"} (= taxid of \code{Homo sapiens})
 }}
 
-\item{reference}{a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.}
+\item{reference}{a logical value indicating whether or not a genome shall be a candidate for downloaded
+if it isn't marked in the database as either a reference genome or a representative genome.
+This is helpful if you don't want to allow "partial genomes" etc.}
 
 \item{skip_bacteria}{Due to its enormous dataset size (> 700MB as of July 2023),
 the bacterial summary file will not be loaded by default anymore. If users

--- a/man/getProteomeSet.Rd
+++ b/man/getProteomeSet.Rd
@@ -28,7 +28,9 @@ shall be retrieved:
 \item{organisms}{a character vector storing the names of the organisms than shall be retrieved.
 There are three available options to characterize an organism:}
 
-\item{reference}{a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.}
+\item{reference}{a logical value indicating whether or not a genome shall be a candidate for downloaded
+if it isn't marked in the database as either a reference genome or a representative genome.
+This is helpful if you don't want to allow "partial genomes" etc.}
 
 \item{release}{a numeric, the database release version of ENSEMBL (\code{db = "ensembl"}). Default is \code{release = NULL} meaning
 that the most recent database version is used. \code{release = 75} would for human would give the stable

--- a/man/getRNA.Rd
+++ b/man/getRNA.Rd
@@ -33,7 +33,9 @@ there are three options to characterize an organism:
 \item by \code{taxonomic identifier from NCBI Taxonomy}: e.g. \code{organism = "9606"} (= taxid of \code{Homo sapiens})
 }}
 
-\item{reference}{a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.}
+\item{reference}{a logical value indicating whether or not a genome shall be a candidate for downloaded
+if it isn't marked in the database as either a reference genome or a representative genome.
+This is helpful if you don't want to allow "partial genomes" etc.}
 
 \item{skip_bacteria}{Due to its enormous dataset size (> 700MB as of July 2023),
 the bacterial summary file will not be loaded by default anymore. If users

--- a/man/getRNASet.Rd
+++ b/man/getRNASet.Rd
@@ -28,7 +28,9 @@ shall be retrieved:
 \item{organisms}{a character vector storing the names of the organisms than shall be retrieved.
 There are three available options to characterize an organism:}
 
-\item{reference}{a logical value indicating whether or not a genome shall be downloaded if it isn't marked in the database as either a reference genome or a representative genome.}
+\item{reference}{a logical value indicating whether or not a genome shall be a candidate for downloaded
+if it isn't marked in the database as either a reference genome or a representative genome.
+This is helpful if you don't want to allow "partial genomes" etc.}
 
 \item{release}{a numeric, the database release version of ENSEMBL (\code{db = "ensembl"}). Default is \code{release = NULL} meaning
 that the most recent database version is used. \code{release = 75} would for human would give the stable

--- a/tests/testthat/test-getGFF.R
+++ b/tests/testthat/test-getGFF.R
@@ -44,6 +44,22 @@ test_that("The getGFF() interface works properly for NCBI Genbank (repeating com
     expect_equal(out1, out2)
 })
 
+test_that("The getGFF() interface works properly for NCBI RefSeq (GTF format)",{
+
+  skip_on_cran()
+  skip_on_travis()
+  # test proper download from refseq
+  out1 <- getGFF( db       = "refseq",
+                  organism = "Saccharomyces cerevisiae",
+                  path = tempdir(), mute_citation = TRUE, format = "gtf")
+
+  out2 <- getGFF( db       = "refseq",
+                  organism = "Saccharomyces cerevisiae",
+                  path = tempdir(), mute_citation = TRUE, format = "gtf")
+  expect_equal(out1, out2)
+})
+
+
 
 test_that("The getGFF() interface works properly for Ensembl (repeating command)",{
         skip_on_cran()


### PR DESCRIPTION
Refseq now has extensive support for .gtf format annotation. Even though not for all species, I thought it was time to add this.

Added 1 new test, and NEWS section + updated documentation for respective functions. 

Version bumped to 1.0.10.

Ready to merge and push to CRAN. 